### PR TITLE
update the storage client with correct scopes

### DIFF
--- a/functions.go
+++ b/functions.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/storage"
+	"google.golang.org/api/option"
 )
 
 // GCSEvent is the payload of a GCS event.
@@ -75,7 +76,7 @@ func IndexJobs(ctx context.Context, e GCSEvent) error {
 		if len(parts) < 4 {
 			return nil
 		}
-		client, err := storage.NewClient(ctx)
+		client, err := storage.NewClient(ctx, option.WithScopes(storage.ScopeReadWrite))
 		if err != nil {
 			return err
 		}
@@ -136,10 +137,10 @@ func IndexJobs(ctx context.Context, e GCSEvent) error {
 		}
 		if _, err := w.Write(data); err != nil {
 			defer w.Close()
-			return fmt.Errorf("failed to link %s to %s", indexPath, u)
+			return fmt.Errorf("failed to link %s to %s: %v", indexPath, u, err)
 		}
 		if err := w.Close(); err != nil {
-			return fmt.Errorf("failed to link %s to %s", indexPath, u)
+			return fmt.Errorf("failed to link %s to %s: %v", indexPath, u, err)
 		}
 		log.Printf("Indexed job %s with state %s to gs://%s/%s", u, state, e.Bucket, indexPath)
 	}

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/openshift/ci-search-functions
 
 go 1.13
 
-require cloud.google.com/go/storage v1.6.0
+require (
+	cloud.google.com/go/storage v1.6.0
+	google.golang.org/api v0.18.0
+)


### PR DESCRIPTION
By default the storage client configures itself with `https://www.googleapis.com/auth/devstorage.full_control` scope, this
requires the credentials to have pretty high priviledges. To support storage object read/write, we need to make sure the
clients use `https://www.googleapis.com/auth/devstorage.read_write` scope.

also updates some error messages to include the error.