### PR TITLE
Fix metric value conversion

### DIFF
--- a/functions.go
+++ b/functions.go
@@ -238,8 +238,8 @@ func IndexJobs(ctx context.Context, e GCSEvent) error {
 					continue
 				}
 				outputMetrics[fmt.Sprintf("%s{%s=%q}", name, label, value)] = OutputMetric{
-					Value:     v.Data.Result[0].Value.Value,
-					Timestamp: v.Data.Result[0].Value.Timestamp,
+					Value:     result.Value.Value,
+					Timestamp: result.Value.Timestamp,
 				}
 				//log.Printf("%s{%s=%q} %s @ %d", name, label, value, result.Value.Value, result.Value.Timestamp)
 			}


### PR DESCRIPTION
Fix a bug where when a metric had multiple series with different label
key/value pairs the conversion was done using only the value of the
first metric.

/assign @smarterclayton 