### PR TITLE
Add support for metrics with multiple labels

### DIFF
--- a/functions.go
+++ b/functions.go
@@ -219,10 +219,6 @@ func IndexJobs(ctx context.Context, e GCSEvent) error {
 			}
 			var label string
 			for i, result := range v.Data.Result {
-				if len(result.Metric) != 1 {
-					log.Printf("warn: Dropped result %d from %s because metric labels were must have length 1 instead of %d", i, name, len(result.Metric))
-					continue
-				}
 				if len(label) == 0 {
 					for k := range result.Metric {
 						label = k


### PR DESCRIPTION
Previously, there was a clause in the conversion function from json to
sqlite that prevented any metric from having more than one label. This
was done for security purposes in order to prevent having big
cardinality explosions. However, this prevented metrics that have valid
use cases from exposing multiple labels such as
`cluster:version:updates:seconds`, which expose the updated version as
well as the version from which the cluster was updated. Thus, to enable
such use cases, we will remove that clause and still make sure to
prevent database explosion by actively reviewing the metrics that are
added to the system.

The conversion function was working under the assumption that all the
metrics hosted on the bucket were only allowed to have one label. Since
we want to support the use case of metrics with multiple labels such as
`cluster:version:updates:seconds`, the function needed to be updated to
return metrics with multiple labels. To do so, instead of treating the
metric selector as only one label key-value pair, changes were made to
treat it as multiple key-value pairs separated by commas.